### PR TITLE
feat: persist the list of names in localstorage so it survives across refreshes

### DIFF
--- a/src/assets/js/Slot.ts
+++ b/src/assets/js/Slot.ts
@@ -1,4 +1,6 @@
 interface SlotConfigurations {
+  /** User configuration for names in the list */
+  nameList?: string[];
   /** User configuration for maximum item inside a reel */
   maxReelItems?: number;
   /** User configuration for whether winner should be removed from name list */
@@ -17,7 +19,7 @@ interface SlotConfigurations {
 /** Class for doing random name pick and animation */
 export default class Slot {
   /** List of names to draw from */
-  private nameList: string[];
+  private nameList: NonNullable<SlotConfigurations['nameList']>;
 
   /** Whether there is a previous winner element displayed in reel */
   private havePreviousWinner: boolean;
@@ -45,6 +47,7 @@ export default class Slot {
 
   /**
    * Constructor of Slot
+   * @param nameList  Names to seed the name list with
    * @param maxReelItems  Maximum item inside a reel
    * @param removeWinner  Whether winner should be removed from name list
    * @param reelContainerSelector  The element ID of reel items to be appended
@@ -53,6 +56,7 @@ export default class Slot {
    */
   constructor(
     {
+      nameList = [],
       maxReelItems = 30,
       removeWinner = true,
       reelContainerSelector,
@@ -61,7 +65,7 @@ export default class Slot {
       onNameListChanged
     }: SlotConfigurations
   ) {
-    this.nameList = [];
+    this.nameList = nameList;
     this.havePreviousWinner = false;
     this.reelContainer = document.querySelector(reelContainerSelector);
     this.maxReelItems = maxReelItems;

--- a/src/assets/js/app.ts
+++ b/src/assets/js/app.ts
@@ -41,6 +41,7 @@ import SoundEffects from '@js/SoundEffects';
     return;
   }
 
+  const LOCAL_STORAGE_KEY = 'random-activity-picker';
   const soundEffects = new SoundEffects();
   const MAX_REEL_ITEMS = 40;
   const CONFETTI_COLORS = ['#26ccff', '#a25afd', '#ff5e7e', '#88ff5a', '#fcff42', '#ffa62d', '#ff36ff'];
@@ -77,6 +78,15 @@ import SoundEffects from '@js/SoundEffects';
     sunburstSvg.style.display = 'none';
   };
 
+  /** Function to persist the state to local storage */
+  const persistNames = () => {
+    // eslint-disable-next-line no-use-before-define
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(slot.names));
+  };
+
+  /** Function to retrieve the state from local storage */
+  const retrieveNames = () => JSON.parse(localStorage[LOCAL_STORAGE_KEY] || '[]');
+
   /**  Function to be trigger before spinning */
   const onSpinStart = () => {
     stopWinningAnimation();
@@ -92,11 +102,13 @@ import SoundEffects from '@js/SoundEffects';
     await soundEffects.win();
     drawButton.disabled = false;
     settingsButton.disabled = false;
+    persistNames();
   };
 
   /** Slot instance */
   const slot = new Slot({
     reelContainerSelector: '#reel',
+    nameList: retrieveNames(),
     maxReelItems: MAX_REEL_ITEMS,
     onSpinStart,
     onSpinEnd,
@@ -154,6 +166,7 @@ import SoundEffects from '@js/SoundEffects';
     slot.names = nameListTextArea.value
       ? nameListTextArea.value.split(/\n/).filter((name) => Boolean(name.trim()))
       : [];
+    persistNames();
     slot.shouldRemoveWinnerFromNameList = removeNameFromListCheckbox.checked;
     soundEffects.mute = !enableSoundCheckbox.checked;
     onSettingsClose();


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
This introduces local storage capability so that the list of names persists between refreshes and browser/open close.

## How has this been tested?
Locally during development, exercised by the linter.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [x] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
Was pretty easy to contribute (:
