### PR TITLE
ci: adjust codeql setting to scan both typescript and javascript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript]
+        language: [javascript-typescript]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Adjust codeql scanning setting to scan TypeScript and JavaScript, according to [documentation](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages).

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `ci`<!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
