### PR TITLE
chore: remove implicit import of core-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 // polyfills
-import 'core-js/stable';
 import 'web-animations-js/web-animations.min';
 import 'element-remove-polyfill';
 


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Remove implicit import of core-js which is duplicate of babel settings `"useBuiltIns": "usage"`

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `chore`<!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
